### PR TITLE
Pass `visitor` to `visit_number!` macro

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -22,12 +22,12 @@ mod macros {
     }
 
     macro_rules! visit_number {
-        ($l: expr, $to: ident, $ty: ident) => {
+        ($l: expr, $to: ident, $ty: ident, $visitor:ident) => {
             if $l.token == Token::$to {
                 paste::expr! {
                     let result = $l.slice().parse().unwrap();
                     $l.advance();
-                    visitor.[<visit_$ty>](result)
+                    $visitor.[<visit_$ty>](result)
                 }
             } else {
                 unexpected_token!($l, "<number>")
@@ -191,70 +191,70 @@ impl<'de: 'a, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, i8)
+        visit_number!(self.lexer, Integer, i8, visitor)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, i16)
+        visit_number!(self.lexer, Integer, i16, visitor)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, i32)
+        visit_number!(self.lexer, Integer, i32, visitor)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, i64)
+        visit_number!(self.lexer, Integer, i64, visitor)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, u8)
+        visit_number!(self.lexer, Integer, u8, visitor)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, u16)
+        visit_number!(self.lexer, Integer, u16, visitor)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, u32)
+        visit_number!(self.lexer, Integer, u32, visitor)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Integer, u64)
+        visit_number!(self.lexer, Integer, u64, visitor)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Float, f32)
+        visit_number!(self.lexer, Float, f32, visitor)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        visit_number!(self.lexer, Float, f64)
+        visit_number!(self.lexer, Float, f64, visitor)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>


### PR DESCRIPTION
In Rust, variable identifiers in a `macro_rules!` body are resolved
in the scope of tht body - they cannot see through to the caller's body.
For example, the following code errors:

```rust
macro_rules! weird_ident {
    () => { my_ident; }
}

fn main() {
    let my_ident = 1;
    weird_ident!();
}
```

However, due to a compiler bug (https://github.com/rust-lang/rust/issues/43081),
this kind of code current compiles when a procedural macro is invoked by
a `macro_rules!` macro. Eventually, this will cause a compilation error.

In the `visit_number!` macro, you're currently writing an expression
involving `visitor`, and passing it to a procedural macro (`paste!`).
However, `visitor` comes from the body of the caller of `visit_number!`,
so this code will stop compiling once the compiler bug is fixed.

Fortunately, the identifier of `visitor` can be passed into
`visit_number!`. This modified code will with the current version of
Rust, as well as future version that causes the old code into an error.

Feel free to ask me about any questions you may have. For more details,
see https://github.com/rust-lang/rust/issues/72622